### PR TITLE
Use php-fpm instead of mod_php

### DIFF
--- a/ansible/hosts.yml
+++ b/ansible/hosts.yml
@@ -3,10 +3,6 @@ all:
     buegelfalte.openrailwaymap.org:
       ansible_become: yes
       apache2_logdir: /var/log/apache2
-      apache2:
-        max_request_workers: 240
-        min_spare_servers: 10
-        max_spare_servers: 20
   vars:
     ansible_python_interpreter: python3
 

--- a/ansible/roles/blog/tasks/main.yml
+++ b/ansible/roles/blog/tasks/main.yml
@@ -5,7 +5,7 @@
   tasks:
   - name: Install required packages from APT
     apt:
-      name: [libapache2-mod-php, apache2, php-xml]
+      name: [php-fpm, apache2, php-xml]
 
   - name: Create directory for Git repository
     file:
@@ -22,14 +22,22 @@
       force: yes
       version: master
 
-  - name: Enable Apache module php
+  - name: Enable Apache modules for php-fpm
     apache2_module:
       name: '{{ item }}'
       state: present
     loop:
-      - 'php7.3'
+      - 'proxy_fcgi'
+      - 'setenvif'
     notify:
       - systemd restart apache2
+
+  - name: Enable php-fpm
+    shell:
+      cmd: a2enconf php7.3-fpm
+      chdir: /etc/apache2/conf-available
+    notify:
+      - systemd reload apache2
 
   - name: Add blog VirtualHost configuration of Apache
     template:

--- a/ansible/roles/tileserver_step2/tasks/main.yml
+++ b/ansible/roles/tileserver_step2/tasks/main.yml
@@ -207,31 +207,6 @@
     notify:
       - systemd reload apache2
 
-  - name: Configure Apache2 MaxRequestWorkers
-    copy:
-      dest: /etc/apache2/conf-available/max_request_workers.conf
-      owner: root
-      group: root
-      mode: 0644
-      content: |
-        {% if apache2.max_request_workers is defined %}
-        MaxRequestWorkers {{ apache2.max_request_workers }}
-        {% endif %}{% if apache2.min_spare_servers %}
-        MinSpareServers {{ apache2.min_spare_servers }}
-        {% endif %}{% if apache2.max_spare_servers %}
-        MaxSpareServers {{ apache2.max_spare_servers }}
-        {% endif %}
-    register: max_request_workers_result
-    when: apache2.max_request_workers is defined or apache2.min_spare_servers is defined or apache2.max_spare_servers is defined
-
-  - name: Enable /etc/apache2/conf-available/max_request_workers.conf
-    shell:
-      cmd: a2enconf max_request_workers.conf
-      chdir: /etc/apache2/conf-available
-    when: max_request_workers_result.changed
-    notify:
-      - systemd reload apache2
-
   - name: Create Tirex configuration for all map styles
     copy:
       dest: '/etc/tirex/renderer/mapnik/{{ item.stylename }}.conf'

--- a/ansible/roles/website/tasks/main.yml
+++ b/ansible/roles/website/tasks/main.yml
@@ -6,7 +6,7 @@
   - name: Install required packages from APT
     apt:
       # package nodejs-legacy is not needed with Debian >= 10 because the nodejs package contains a symlink /usr/bin/nodejs
-      name: [postgresql-common, php-gettext, unzip, zip, python3-pip, npm, nodejs, wget, php-pgsql, libapache2-mod-php, apache2, python3-pil, python3-cairo, python3-ply]
+      name: [postgresql-common, php-gettext, unzip, zip, python3-pip, npm, nodejs, wget, php-pgsql, php-fpm, apache2, python3-pil, python3-cairo, python3-ply]
 
   - name: Install pojson from Pip
     pip:
@@ -32,7 +32,7 @@
   - name: 'OpenRailwayMap API: Change database table prefix'
     lineinfile:
       backrefs: yes
-      path: '{{ website_dir }}/api/config.json' 
+      path: '{{ website_dir }}/api/config.json'
       regexp: '{{ item.regex }}'
       line: '{{ item.replacement }}'
     loop:
@@ -50,12 +50,12 @@
 
   - name: Download and install Leaflet and its plugins
     make:
-      chdir: '{{ website_dir }}' 
+      chdir: '{{ website_dir }}'
       target: install-deps
 
   - name: Build MapCSS styles, JOSM presets and locales
     make:
-      chdir: '{{ website_dir }}/{{ item }}' 
+      chdir: '{{ website_dir }}/{{ item }}'
       target: all
     loop:
       - 'josm-presets'
@@ -68,7 +68,7 @@
     postgresql_ext:
       db: '{{ osm_dbname }}'
       name: '{{ item }}'
-    loop: 
+    loop:
       - 'postgis_topology'
       - 'postgis_sfcgal'
 
@@ -121,7 +121,7 @@
     become: true
     become_user: postgres
     postgresql_privs:
-      role: openrailwaymap 
+      role: openrailwaymap
       type: table
       objs: ALL_IN_SCHEMA
       privs: 'SELECT'
@@ -129,7 +129,7 @@
 
   - name: Change PostgreSQL version in the Systemd unit file of the API
     lineinfile:
-      path: '{{ website_dir }}/api/orm-api.service' 
+      path: '{{ website_dir }}/api/orm-api.service'
       regexp: '{{ item.regex }}'
       line: '{{ item.replacement }}'
     loop:
@@ -139,7 +139,7 @@
   - name: Install Rsyslogd configuration for the API
     become: yes
     make:
-      chdir: '{{ website_dir }}/api' 
+      chdir: '{{ website_dir }}/api'
       target: install-rsyslog
     notify:
       - systemd restart rsyslog
@@ -147,7 +147,7 @@
   - name: Build and install Systemd unit file of the API
     become: yes
     make:
-      chdir: '{{ website_dir }}/api' 
+      chdir: '{{ website_dir }}/api'
       target: install-systemd
     notify:
       - systemd daemon-reload


### PR DESCRIPTION
This is switching the PHP integration from mod_php to php-fpm and allows to use Apache's event MPM.

The switch on an existing installation:

```
dpkg --purge libapache2-mod-php libapache2-mod-php7.3
apt -y install php-fpm
a2enmod proxy_fcgi setenvif
a2enconf php7.3-fpm
a2dismod mpm_prefork
a2enmod mpm_event
rm /etc/apache2/conf-enabled/max_request_workers.conf
systemctl restart apache2
```

The tuning of Apache and FPM pool parameters is missing here, as I have no idea about the actual profile of the production instance, so I'll leave that to upstream.