### PR TITLE
enable HTTP/2

### DIFF
--- a/ansible/roles/blog/tasks/main.yml
+++ b/ansible/roles/blog/tasks/main.yml
@@ -37,6 +37,8 @@
         state: 'absent'
       - name: 'mpm_event'
         state: 'present'
+      - name: 'http2'
+        state: 'present'
     notify:
       - systemd restart apache2
 


### PR DESCRIPTION
closes GH-8

Disclaimer: untested, because I don't have SSL in my dev-installation.